### PR TITLE
fix: (.zshrc): do not show all subtrees

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -72,7 +72,7 @@ _fzf_compgen_dir() {
 
 source ~/fzf-git.sh/fzf-git.sh
 
-show_file_or_dir_preview="if [ -d {} ]; then eza --tree --color=always {} | head -200; else bat -n --color=always --line-range :500 {}; fi"
+show_file_or_dir_preview="if [ -d {} ]; then eza --tree -L=1 --color=always {} | head -200; else bat -n --color=always --line-range :500 {}; fi"
 
 export FZF_CTRL_T_OPTS="--preview '$show_file_or_dir_preview'"
 export FZF_ALT_C_OPTS="--preview 'eza --tree --color=always {} | head -200'"


### PR DESCRIPTION
A minuscule update on the tree preview: instead of showing everything in the preview, show only the first level (depth=1) of directories. Useful when you have a gazillion subtrees like node_modules etc.